### PR TITLE
Feature: frontmatter metadata section

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -44,7 +44,7 @@ type RunCmd struct {
 }
 
 type TestCmd struct {
-	File string `help:"File to test"`
+	File string `arg:"" help:"File to test"`
 }
 
 // CheckIfError should be used to naively panics if an error is not nil.
@@ -101,9 +101,23 @@ func (r *RunCmd) Run(globals *Globals) error {
 	return nil
 }
 
+func (c *TestCmd) Run(globals *Globals) error {
+	fileData, err := os.ReadFile(c.File)
+	if err != nil {
+		return err
+	}
+	parsed, err := basi.DebugParse(c.File, bytes.NewBuffer(fileData))
+	if err != nil {
+		return err
+	}
+	fmt.Printf("parsed %v", parsed)
+	return nil
+}
+
 type CLI struct {
 	Globals
-	Run RunCmd `cmd:"" help:"Run tests using basi"`
+	Run  RunCmd  `cmd:"" help:"Run tests using basi"`
+	Test TestCmd `cmd:"" help:"Test a .basi file for syntax"`
 }
 
 func main() {

--- a/lib.go
+++ b/lib.go
@@ -100,14 +100,28 @@ var (
 )
 
 type PlaywrightAction struct {
-	Meta *FrontMatter `@@`
+	Meta    *FrontMatter `@@`
+	Actions []*Action    `@@*`
+}
 
-	Actions []*Action `@@*`
+func (p *PlaywrightAction) GetMetaFieldString(name string) string {
+	if p.Meta == nil {
+		return ""
+	}
+	if p.Meta.Fields == nil {
+		return ""
+	}
+	for _, field := range p.Meta.Fields {
+		if field.Name == name {
+			return field.Value
+		}
+	}
+	return ""
 }
 
 type FrontMatter struct {
 	Fields    []*MetaField `@@*`
-	Separator *string      `@Separator`
+	Separator *string      `@Separator*`
 }
 
 type MetaField struct {

--- a/lib.go
+++ b/lib.go
@@ -81,7 +81,7 @@ func lexerActionsFromMap() string {
 var (
 	actionLexer = lexer.MustSimple([]lexer.SimpleRule{
 		{`Action`, lexerActionsFromMap()},
-		{`MetaField`, `ID|Title|URL|Description|Headless|Browsers|ScreenSizes|Extends`},
+		{`MetaField`, `ID|Title|URL|Description|Headless|Browser`}, // TODO: support ScreenSizes, Extends
 		{`Ident`, `[a-zA-Z][a-zA-Z_\d]*`},
 		{`String`, `"(?:\\.|[^"])*"`},
 		{`Selector`, `"(?:\\.|[^"])*"`},

--- a/lib.go
+++ b/lib.go
@@ -81,11 +81,14 @@ func lexerActionsFromMap() string {
 var (
 	actionLexer = lexer.MustSimple([]lexer.SimpleRule{
 		{`Action`, lexerActionsFromMap()},
+		{`MetaField`, `ID|Title|URL|Description|Headless|Browsers|ScreenSizes|Extends`},
 		{`Ident`, `[a-zA-Z][a-zA-Z_\d]*`},
 		{`String`, `"(?:\\.|[^"])*"`},
 		{`Selector`, `"(?:\\.|[^"])*"`},
 		{"comment", `[#;][^\n]*`},
 		{"Whitespace", `[ \s]+`},
+		{"Colon", `[:]+`},
+		{"Separator", `\-{3}`},
 		{"EOL", `[\n\r]+`},
 	})
 	parser = participle.MustBuild[PlaywrightAction](
@@ -97,7 +100,20 @@ var (
 )
 
 type PlaywrightAction struct {
+	Meta *FrontMatter `@@`
+
 	Actions []*Action `@@*`
+}
+
+type FrontMatter struct {
+	Fields    []*MetaField `@@*`
+	Separator *string      `@Separator`
+}
+
+type MetaField struct {
+	// Pos   lexer.Position
+	Name  string `@MetaField`
+	Value string `":" @String`
 }
 
 type Action struct {

--- a/lib_test.go
+++ b/lib_test.go
@@ -48,13 +48,19 @@ func TestParseFail(t *testing.T) {
 func TestParseMetadata(t *testing.T) {
 	cases := []string{
 		`ID            : "Some random ID"
+---
+Goto "https://nndi.cloud"
+`,
+		`ID            : "Some random ID without separator"
+
+Goto "https://nndi.cloud"
+`,
+		`ID            : "Some random ID"
 URL           : "https://nndi.cloud"
 Title         : "Navigate to home on nndi"
 Headless      : "yes"
 Description   : "Navigates to the NNDI website and clicks the Home link"
-Browsers      : "chromium"
-ScreenSizes   : "1080x800"
-Extends       : "./base.basi;Browsers,ScreenSizes,Devices,NetworkSpeed"
+Browser       : "chromium"
 ---
 Goto "https://nndi.cloud"
 Click "#navbar > ul > li.active > a"
@@ -66,7 +72,7 @@ Screenshot "body" "./test-nndi.png"
 	for _, content := range cases {
 		_, err := Parse("test.yaml", strings.NewReader(content))
 		if err != nil {
-			t.Errorf("test failed with content: %s", content)
+			t.Errorf("test failed with error: %v on \n\t%s", err, content)
 		}
 	}
 }

--- a/lib_test.go
+++ b/lib_test.go
@@ -44,3 +44,29 @@ func TestParseFail(t *testing.T) {
 		}
 	}
 }
+
+func TestParseMetadata(t *testing.T) {
+	cases := []string{
+		`ID            : "Some random ID"
+URL           : "https://nndi.cloud"
+Title         : "Navigate to home on nndi"
+Headless      : "yes"
+Description   : "Navigates to the NNDI website and clicks the Home link"
+Browsers      : "chromium"
+ScreenSizes   : "1080x800"
+Extends       : "./base.basi;Browsers,ScreenSizes,Devices,NetworkSpeed"
+---
+Goto "https://nndi.cloud"
+Click "#navbar > ul > li.active > a"
+ExpectAttr "data-nav-section" "home"
+Screenshot "body" "./test-nndi.png"
+`,
+	}
+
+	for _, content := range cases {
+		_, err := Parse("test.yaml", strings.NewReader(content))
+		if err != nil {
+			t.Errorf("test failed with content: %s", content)
+		}
+	}
+}

--- a/playwright/expect.go
+++ b/playwright/expect.go
@@ -47,6 +47,8 @@ func performAssertion(assertions playwrightgo.PlaywrightAssertions, locator play
 		return ExpectToHaveAccessibleErrorMessage(assertions, locator, action)
 	case "accessiblename":
 		return ExpectToHaveAccessibleName(assertions, locator, action)
+	case "attr":
+		return ExpectToHaveAttribute(assertions, locator, action)
 	case "attribute":
 		return ExpectToHaveAttribute(assertions, locator, action)
 	case "class":

--- a/playwright/playwright.go
+++ b/playwright/playwright.go
@@ -10,7 +10,6 @@ import (
 
 	playwrightgo "github.com/playwright-community/playwright-go"
 	"github.com/zikani03/basi"
-	"github.com/zikani03/basi/core"
 )
 
 const Name = "playwright"
@@ -23,7 +22,6 @@ type Executor struct {
 	Device      string           `json:"device" yaml:"device"`
 	Actions     []ExecutorAction `json:"actions" yaml:"actions"`
 	Headless    bool             `json:"headless" yaml:"headless"`
-	Assertions  []core.Assertion `json:"assertions,omitempty" yaml:"assertions,omitempty"`
 }
 
 type ExecutorAction struct {
@@ -98,6 +96,9 @@ func (e *Executor) Run(ctx context.Context) (interface{}, error) {
 		return nil, fmt.Errorf("could not launch playwright: %w", err)
 	}
 
+	if e.Name != "" {
+		fmt.Printf("Running: \033[10;1;1m%s\033[0m on\033[32;1;4m(%s)\033[0m\n", e.Name, e.Browser)
+	}
 	pw, err := playwrightgo.Run()
 	if err != nil {
 		return nil, fmt.Errorf("could not launch playwright: %w", err)


### PR DESCRIPTION
This PR adds support for parsing a frontmatter or metadata section that can be used to configure an execution. The metadata section parsing is based on #6.


Closes #6