### PR TITLE
feat(find-action): add Find action to select a locator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,54 +1,34 @@
 # basi
 
 `basi` allow users and developers to author and run Playwright actions using a simple
-configuration file with less code. 
+configuration file with less code. Browser automation steps are written in `.basi` files. 
 
-`basi` supports writing playwright actions as either `.yaml` or `.basi` files. The goal
-is for the .basi file DSL to be simple enough to hand over to non-technical users.
+The goal is for the .basi file DSL to be simple enough to hand over to non-technical users.
 
 > NOTE: `basi` is still in very early development. There are no guarantees about API or feature stability.
 
-## Building 
+## Installation 
+
+Download a binary from the [GitHub Releases](https://github.com/zikani03/basi/releases) and place it on your $PATH.
+
+> NOTE: `basi` depends on Playwright and needs to download some
+> browsers and tools if playwright if it is not already installed.
+> You will notice this the first time you run the test/files
+
+If you want to contribute or build from the source code see the [Building](#building) section
+
+Once installed you can then run it :
 
 ```sh
-$ git clone https://github.com/zikani03/basi
-
-$ cd basi
-
-$ go build -o basi ./cmd/main.go
-
-$ ./basi --help
-
-# Test with the example file in the repo
-
-$ ./basi run example-hn.basi --url "https://news.ycombinator.com"
+$ basi --help
 ```
 
 ## Example usage
 
-> NOTE: the `basi` depends on Playwright and as a result, will
-> attempt to install playwright if it is not already installed.
-> you will notice this the first time you run the test/files
-
-Create a file named `basic.yaml`
-
-```yaml
-name: Try to login to HackerNews
-description: Test login to hacker news
-url: https://news.ycombinator.com
-headless: false
-actions:
-  - { action: Goto,       selector: "/login" }
-  - { action: Fill,       selector: "input[name=acct]", content: "throwaway-user" }
-  - { action: Fill,       selector: "input[name=pw]", content:  "fakepassword" }
-  - { action: Click,      selector: "input[value=login]" }
-  - { action: Screenshot, selector: "body", content: "./test-screenshot.png" }
-```
-
-The equivalent `basic.basi` file can be authored like this
+Create a file named `example-hn.basi` file with the following content:
 
 ```
-Goto "/login"
+Goto "https://news.ycombinator.com/login"
 Fill "input[name=acct]" "throwaway-username" 
 Fill "input[name=pw]" "fakepassword"
 Click "input[value=login]"
@@ -58,13 +38,31 @@ Screenshot "body" "./test-screenshot.png"
 You can now run the file using basi, like so:
 
 ```sh 
-$ ./basi run basic.yaml
+$ basi run example-hn.basi
 ```
 
-Or 
+**You can use `Find` to select an element to run assertions on it**
 
-```sh 
-$ ./basi run basic.basi --url "https://news.ycombinator.com"
+```
+Goto "https://github.com/"
+Find "Build and ship software on a single, collaborative platform"
+ExpectId "hero-section-brand-heading"
+Screenshot "body" "./data/test-github.png"
+```
+
+**You can setup metadata/configuration for each run in a `frontmatter` section**
+
+```
+ID            : "A random ID to identify the run"
+URL           : "https://nndi.cloud/"
+Title         : "Navigate to home on nndi"
+Headless      : "yes"
+Description   : "Navigates to the NNDI website and clicks the Home link"
+---
+Goto "/"
+Click "#navbar > ul > li.active > a"
+ExpectAttr "data-nav-section" "home"
+Screenshot "body" "./test-nndi.png"
 ```
 
 ## Available actions
@@ -77,6 +75,7 @@ $ ./basi run basic.basi --url "https://news.ycombinator.com"
 |Focus                 |**querySelector**| Focus "#element" |
 |Blur                  |**querySelector**| Blur "#element" |
 |Fill                  |**querySelector** TEXT| Fill "#element" "my input text" |
+|Find                  |**textContent or querySelector**| Find "My Account" |
 |Clear                 |**querySelector**| Clear "#element" |
 |Check                 |**querySelector**| Check "#element" |
 |Uncheck               |**querySelector**| Uncheck "#element" |
@@ -126,6 +125,22 @@ $ ./basi run basic.basi --url "https://news.ycombinator.com"
 |ExpectClass| **className** | ExpectClass "a-class-name" |
 |ExpectCSS| **css-property** **argument** | ExpectCSS "display" "flex" |
 |ExpectId| **argument** | ExpectId "an-id" |
+
+## Building 
+
+```sh
+$ git clone https://github.com/zikani03/basi
+
+$ cd basi
+
+$ go build -o basi ./cmd/main.go
+
+$ ./basi --help
+
+# Test with the example file in the repo
+
+$ ./basi run example-hn.basi --url "https://news.ycombinator.com"
+```
 
 ## LICENSE
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,8 +8,8 @@ Some notes about basi
 
 ## Objectives
 
-- Support YAML and .basi files
-- Support Assertions for full end-to-end testing flow
+- [x] Support YAML and .basi files
+- [x] Support Assertions for full end-to-end testing flow
 - Generate structured output files for integration into (CLIs, AI Agents, general system integrations/connects)
 - Support 95% of Playwright actions that can be done on programmatic SDKs
 - Support running playwright `--local`, `--docker` and `--remote`
@@ -31,12 +31,11 @@ The Lexer and Parser for the DSL is implemented using [participle](https://githu
 ## IDEAS
 
 ```
-[Config]
-  name: 
-  url: "https://localhost:5173"
-  headless: true 
-  device: "Samsung Galaxy"
-
+Title    : "Some test"
+URL      : "https://localhost:5173"
+Headless : "yes" 
+Browser  : "chromium"
+---
 Use "./login.basi"
 
 Fill       "#email" "change@example.com" 
@@ -47,7 +46,4 @@ Click      "#loginButton"
 WaitFor    ".second-dashboard-user-name"
 
 Use "./generate-document.basi"
-
-[Asserts]
-page body is "something"
 ```

--- a/lib.go
+++ b/lib.go
@@ -22,6 +22,7 @@ var actionMap = map[string]ActionFunc{
 	"Blur":                         StubExpectAction,
 	"Clear":                        StubExpectAction,
 	"Fill":                         StubExpectAction,
+	"Find":                         StubExpectAction,
 	"Check":                        StubExpectAction,
 	"Uncheck":                      StubExpectAction,
 	"FillCheckbox":                 StubExpectAction,

--- a/playwright/actions.go
+++ b/playwright/actions.go
@@ -24,6 +24,7 @@ var actionMap = map[string]ActionFunc{
 	"Blur":                  BlurAction,
 	"Clear":                 ClearAction,
 	"Fill":                  FillAction,
+	"Find":                  StubExpectAction,
 	"Check":                 CheckAction,
 	"Uncheck":               UncheckAction,
 	"FillCheckbox":          CheckAction, // alias for Check


### PR DESCRIPTION
The Find action selects an element for use for assertions. This allows users to perform assertions without necessarily interacting with the DOM element via an event trigger.

## Example

This should work

```
Goto "https://github.com/"
Find "Build and ship software on a single, collaborative platform"
ExpectId "hero-section-brand-heading"
Screenshot "body" "./data/test-github.png"
```

Closes #11