### PR TITLE
feat: Add run-doc subcommand to run the test and generate markdown docs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,4 +16,4 @@ jobs:
           go-version: 1.24.2
       - uses: actions/checkout@v2
       - name: run go mod
-        run: go mod tidy && go build ./cmd/main.go
+        run: go mod tidy && go build -o basi ./cmd/

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -14,7 +14,7 @@ tasks:
   build:
     deps: [ clean ]
     cmds:
-      - go build -ldflags="-X 'basi.Version=$(git describe  --tags --candidates 1)'" -o build/basi ./cmd/main.go
+      - go build -ldflags="-X 'basi.Version=$(git describe  --tags --candidates 1)'" -o build/basi ./cmd/
   
   install-local:
     deps: [ build ]

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,18 +1,10 @@
 package main
 
 import (
-	"bytes"
-	"cmp"
-	"context"
 	"fmt"
-	"log/slog"
 	"os"
-	"strings"
 
 	"github.com/alecthomas/kong"
-	"github.com/zikani03/basi"
-	"github.com/zikani03/basi/playwright"
-	"gopkg.in/yaml.v2"
 )
 
 var version string = "0.0.0"
@@ -34,20 +26,6 @@ func (v VersionFlag) BeforeApply(app *kong.Kong, vars kong.Vars) error {
 	return nil
 }
 
-type RunCmd struct {
-	File      string `arg:"" help:"filename for file to run"`
-	Directory string `short:"d" help:"directory containing .basi files to be run"`
-	URL       string `short:"u" help:"which url to run the test against"`
-	Remote    bool   `help:"whether to run remote test"`
-	Docker    bool   `help:"whether to run tests inside docker"`
-	Local     bool   `help:"whether to install playwright locally and run tests"`
-	OutputDir string `short:"o" help:"Where to write test output and screenshots"`
-}
-
-type TestCmd struct {
-	File string `arg:"" help:"File to test"`
-}
-
 // CheckIfError should be used to naively panics if an error is not nil.
 func CheckIfError(err error) {
 	if err == nil {
@@ -58,70 +36,11 @@ func CheckIfError(err error) {
 	os.Exit(1)
 }
 
-func (r *RunCmd) Run(globals *Globals) error {
-	fileData, err := os.ReadFile(r.File)
-	if err != nil {
-		return err
-	}
-
-	executor := &playwright.Executor{}
-	actions := make([]playwright.ExecutorAction, 0)
-
-	if strings.HasSuffix(r.File, ".basi") {
-		parsed, err := basi.Parse(r.File, bytes.NewBuffer(fileData))
-		if err != nil {
-			return err
-		}
-
-		for _, p := range parsed.Actions {
-			actions = append(actions, *playwright.NewExecutorAction(p))
-		}
-
-		headless := parsed.GetMetaFieldString("Headless") == "yes" || globals.Headless
-		executor = &playwright.Executor{
-			Name:        parsed.GetMetaFieldString("Title"),
-			Description: parsed.GetMetaFieldString("Description"),
-			URL:         cmp.Or(parsed.GetMetaFieldString("URL"), r.URL),
-			Browser:     cmp.Or(parsed.GetMetaFieldString("Browsers"), globals.Browser),
-			Headless:    headless,
-			Actions:     actions,
-		}
-
-	} else if strings.HasSuffix(r.File, ".yaml") || strings.HasSuffix(r.File, ".yml") {
-		if err := yaml.Unmarshal(fileData, executor); err != nil {
-			return fmt.Errorf("unable to parse step got: %v", err)
-		}
-
-	} else {
-		return fmt.Errorf("failed to run, invalid file specified: %s", r.File)
-	}
-
-	slog.Debug("running the executor", "url", executor.URL)
-	_, err = executor.Run(context.Background())
-	if err != nil {
-		return err
-	}
-	slog.Debug("executed sucessfully")
-	return nil
-}
-
-func (c *TestCmd) Run(globals *Globals) error {
-	fileData, err := os.ReadFile(c.File)
-	if err != nil {
-		return err
-	}
-	parsed, err := basi.DebugParse(c.File, bytes.NewBuffer(fileData))
-	if err != nil {
-		return err
-	}
-	fmt.Printf("parsed %v", parsed)
-	return nil
-}
-
 type CLI struct {
 	Globals
-	Run  RunCmd  `cmd:"" help:"Run tests using basi"`
-	Test TestCmd `cmd:"" help:"Test a .basi file for syntax"`
+	Run    RunCmd    `cmd:"" help:"Run tests using basi"`
+	RunDoc RunDocCmd `cmd:"" help:"Experimental feature to generate docs from steps"`
+	Test   TestCmd   `cmd:"" help:"Test a .basi file for syntax"`
 }
 
 func main() {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"cmp"
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+
+	"github.com/zikani03/basi"
+	"github.com/zikani03/basi/playwright"
+	"gopkg.in/yaml.v2"
+)
+
+type RunCmd struct {
+	File      string `arg:"" help:"filename for file to run"`
+	Directory string `short:"d" help:"directory containing .basi files to be run"`
+	URL       string `short:"u" help:"which url to run the test against"`
+	Remote    bool   `help:"whether to run remote test"`
+	Docker    bool   `help:"whether to run tests inside docker"`
+	Local     bool   `help:"whether to install playwright locally and run tests"`
+	OutputDir string `short:"o" help:"Where to write test output and screenshots"`
+}
+
+func (r *RunCmd) Run(globals *Globals) error {
+	fileData, err := os.ReadFile(r.File)
+	if err != nil {
+		return err
+	}
+
+	executor := &playwright.Executor{}
+	actions := make([]playwright.ExecutorAction, 0)
+
+	if strings.HasSuffix(r.File, ".basi") {
+		parsed, err := basi.Parse(r.File, bytes.NewBuffer(fileData))
+		if err != nil {
+			return err
+		}
+
+		for _, p := range parsed.Actions {
+			actions = append(actions, *playwright.NewExecutorAction(p))
+		}
+
+		headless := parsed.GetMetaFieldString("Headless") == "yes" || globals.Headless
+		executor = &playwright.Executor{
+			Name:        parsed.GetMetaFieldString("Title"),
+			Description: parsed.GetMetaFieldString("Description"),
+			URL:         cmp.Or(parsed.GetMetaFieldString("URL"), r.URL),
+			Browser:     cmp.Or(parsed.GetMetaFieldString("Browsers"), globals.Browser),
+			Headless:    headless,
+			Actions:     actions,
+		}
+
+	} else if strings.HasSuffix(r.File, ".yaml") || strings.HasSuffix(r.File, ".yml") {
+		if err := yaml.Unmarshal(fileData, executor); err != nil {
+			return fmt.Errorf("unable to parse step got: %v", err)
+		}
+
+	} else {
+		return fmt.Errorf("failed to run, invalid file specified: %s", r.File)
+	}
+
+	slog.Debug("running the executor", "url", executor.URL)
+	_, err = executor.Run(context.Background())
+	if err != nil {
+		return err
+	}
+	slog.Debug("executed sucessfully")
+	return nil
+}

--- a/cmd/rundoc.go
+++ b/cmd/rundoc.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+
+	"github.com/zikani03/basi"
+	"github.com/zikani03/basi/internal/experimental/docgen"
+)
+
+type RunDocCmd struct {
+	RunCmd
+}
+
+func (c *RunDocCmd) Run(globals *Globals) error {
+	fileData, err := os.ReadFile(c.File)
+	if err != nil {
+		return err
+	}
+	parsed, err := basi.Parse(c.File, bytes.NewBuffer(fileData))
+	if err != nil {
+		return err
+	}
+	filename, err := docgen.GenerateStepsFromActions(c.File, c.URL, parsed, globals.Debug)
+	if err != nil {
+		return fmt.Errorf("failed to generate document: %v", err)
+	}
+	fmt.Printf("Generated file at %s", filename)
+	return nil
+}

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+
+	"github.com/zikani03/basi"
+)
+
+type TestCmd struct {
+	File string `arg:"" help:"File to test"`
+}
+
+func (c *TestCmd) Run(globals *Globals) error {
+	fileData, err := os.ReadFile(c.File)
+	if err != nil {
+		return err
+	}
+	parsed, err := basi.DebugParse(c.File, bytes.NewBuffer(fileData))
+	if err != nil {
+		return err
+	}
+	fmt.Printf("parsed %v", parsed)
+	return nil
+}

--- a/example-hn.basidoc.md
+++ b/example-hn.basidoc.md
@@ -1,0 +1,22 @@
+# Test Document for  
+
+Documented by Basi
+
+1. Goto https://news.ycombinator.com/login
+
+![[Figure 2]](./step-0.png)
+
+2. Fill input[name=acct]
+
+![[Figure 3]](./step-1.png)
+
+3. Fill input[name=pw]
+
+![[Figure 4]](./step-2.png)
+
+4. Click input[value=login]
+
+![[Figure 5]](./step-3.png)
+
+![[Figure 5]](./test-screenshot.png)
+

--- a/example-hn.basidoc.md
+++ b/example-hn.basidoc.md
@@ -4,19 +4,19 @@ Documented by Basi
 
 1. Goto https://news.ycombinator.com/login
 
-![[Figure 2]](./step-0.png)
+![[Figure 2]](example-hn-step-0.png)
 
 2. Fill input[name=acct]
 
-![[Figure 3]](./step-1.png)
+![[Figure 3]](example-hn-step-1.png)
 
 3. Fill input[name=pw]
 
-![[Figure 4]](./step-2.png)
+![[Figure 4]](example-hn-step-2.png)
 
 4. Click input[value=login]
 
-![[Figure 5]](./step-3.png)
+![[Figure 5]](example-hn-step-3.png)
 
-![[Figure 5]](./test-screenshot.png)
+![[Figure 5]](test-screenshot.png)
 

--- a/internal/experimental/docgen/README.md
+++ b/internal/experimental/docgen/README.md
@@ -1,0 +1,5 @@
+# docgen
+
+This is an experimental functionality of Basi to enable 
+generating markdown documentation from basi spec files.
+

--- a/internal/experimental/docgen/docgen.go
+++ b/internal/experimental/docgen/docgen.go
@@ -1,0 +1,92 @@
+package docgen
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/alecthomas/repr"
+	"github.com/zikani03/basi"
+	"github.com/zikani03/basi/playwright"
+)
+
+func GenerateStepsFromActions(filename, url string, spec *basi.PlaywrightAction, debug bool) (string, error) {
+	actions, err := cloneAndaddScreenShotSteps(spec)
+	if err != nil {
+		return "", err
+	}
+	spec.Actions = actions
+	if debug {
+		repr.Println(actions, repr.Indent("  "), repr.OmitEmpty(true))
+	}
+
+	executableActions := make([]playwright.ExecutorAction, 0)
+	for _, p := range spec.Actions {
+		executableActions = append(executableActions, *playwright.NewExecutorAction(p))
+	}
+	headless := spec.GetMetaFieldString("Headless") == "yes" // || globals.Headless
+
+	executor := &playwright.Executor{
+		Name:        spec.GetMetaFieldString("Title"),
+		Description: spec.GetMetaFieldString("Description"),
+		URL:         cmp.Or(spec.GetMetaFieldString("URL"), url),
+		// Browser:     cmp.Or(spec.GetMetaFieldString("Browsers"), globals.Browser),
+		Headless: headless,
+		Actions:  executableActions,
+	}
+
+	_, err = executor.Run(context.Background())
+	if err != nil {
+		return "", err
+	}
+	// create a test file
+	f, err := os.Create(filename + "doc.md")
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	fmt.Fprintf(f, "# Test Document for %s \n\n", spec.GetMetaFieldString("Title"))
+	f.WriteString("Documented by Basi\n\n")
+	stepNo := 1
+	for _, action := range actions {
+		if action.Action == "Screenshot" {
+			fmt.Fprintf(f, "![[Figure %d]](%s)\n\n", stepNo, action.Arguments.String)
+			continue
+		}
+		fmt.Fprintf(f, "%d. %s %s\n\n", stepNo, action.Action, selectorToHuman(action.Selector.Selector))
+		stepNo += 1
+	}
+	return filename, nil
+}
+
+func selectorToHuman(selector string) string {
+	// TODO: parse selector and use heuristics for best case of human representation of it
+	return selector
+}
+
+func cloneAndaddScreenShotSteps(spec *basi.PlaywrightAction) ([]*basi.Action, error) {
+	newActions := make([]*basi.Action, 0)
+	for idx, action := range spec.Actions {
+		if action.Action == "" {
+			return nil, fmt.Errorf("action cannot be empty or nil at: %d", idx)
+		}
+
+		newActions = append(newActions, action)
+		// no need to add a screenshot when we are already doing a screenshot step
+		if action.Action == "Screenshot" {
+			continue
+		}
+		// just add a screenshot step
+		newActions = append(newActions, &basi.Action{
+			Action: "Screenshot",
+			Selector: &basi.Selector{
+				Selector: "body", // how to get the best screenshot element?
+			},
+			Arguments: &basi.String{
+				String: fmt.Sprintf("./step-%d.png", idx),
+			},
+		})
+	}
+	return newActions, nil
+}


### PR DESCRIPTION
This changeset adds a new sub-command named run-doc which can be used to generate markdown from the steps in the .basi file as a way to aid in documenting steps for applications in addition to testing them.

This is very early and very experimental, lot's of things to figure out. But it works okay enough for a first pass,

Usage:

```sh
$ basi run-doc example-hn.basi
```

You will get a markdown with the following (Screenshots are added between each step and referenced in the markdown  ):

```markdown
# Test Document for  

Documented by Basi

1. Goto https://news.ycombinator.com/login

![[Figure 2]](./step-0.png)

2. Fill input[name=acct]

![[Figure 3]](./step-1.png)

3. Fill input[name=pw]

![[Figure 4]](./step-2.png)

4. Click input[value=login]

![[Figure 5]](./step-3.png)

![[Figure 5]](./test-screenshot.png)
```