### PR TITLE
fix: return error when find doesn't match any element closes #21

### DIFF
--- a/playwright/playwright.go
+++ b/playwright/playwright.go
@@ -176,11 +176,16 @@ func performActions(ctx context.Context, page playwrightgo.Page, actions []Execu
 
 		if actionName == "Find" {
 			if loc, err := tryFindLocator(page, action); err != nil {
-				return fmt.Errorf("failed to find a element on the page using: '%s'", action.Content)
+				return fmt.Errorf("failed to find a element on the page using: '%s'", cmp.Or(action.Selector, action.Content))
 			} else {
 				lastLocator = loc
 			}
-			continue
+			numMatched, err := lastLocator.Count()
+			if numMatched <= 0 || err != nil {
+				return fmt.Errorf("failed to find a element on the page using: '%s'", cmp.Or(action.Selector, action.Content))
+			} else {
+				continue
+			}
 		}
 
 		if strings.HasPrefix(actionName, "Expect") {

--- a/playwright/playwright_test.go
+++ b/playwright/playwright_test.go
@@ -101,3 +101,50 @@ func TestPerformActions(t *testing.T) {
 		}
 	})
 }
+
+func TestPerformFindOnEmptyElement(t *testing.T) {
+
+	testActions := []ExecutorAction{
+		{Action: "Find", Selector: "does-not-exist", Content: "does-not-exist"},
+	}
+
+	pw, err := playwrightgo.Run()
+	if err != nil {
+		t.Fail()
+	}
+	browser, err := pw.Chromium.Launch(playwrightgo.BrowserTypeLaunchOptions{
+		Headless: playwrightgo.Bool(true),
+	})
+	if err != nil {
+		t.Fail()
+	}
+	browserCtx, err := browser.NewContext()
+	if err != nil {
+		t.Fail()
+	}
+	page, err := browserCtx.NewPage()
+	if err != nil {
+		t.Fail()
+	}
+
+	err = page.SetContent(testPage, playwrightgo.PageSetContentOptions{})
+	if err != nil {
+		t.Error("failed to set testPage content")
+	}
+
+	err = performActions(context.Background(), page, testActions)
+	if err == nil {
+		t.Errorf("expected error while performing actions")
+	}
+
+	t.Cleanup(func() {
+		err = browser.Close()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to close browser properly %v", err)
+		}
+		err = pw.Stop()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to close browser properly %v", err)
+		}
+	})
+}


### PR DESCRIPTION
The Find action was not returning an error when not matched to an element in the DOM. This PR fixes that